### PR TITLE
Fix AEM timestamp frame alignment

### DIFF
--- a/ambiviz/ambisonics/audio_to_aem.py
+++ b/ambiviz/ambisonics/audio_to_aem.py
@@ -96,15 +96,19 @@ def compute_aem(
     if sr_ != sr:
         raise ValueError(f"Audio files have different sample rates: {sr_} and {sr}.")
 
-    # compute the timestamp of each AEM frame
-    time_stamp = np.arange(0, y.shape[1] - audio_frame_length, audio_hop_length) / sr_
-
-    # compute aem
-    # aem shape:
+    # Compute AEM first.
+    # AEM shape:
     # (n_frames, n_phi, n_nu) in aem mode
     # (n_frames, n_phi, n_nu, n_mels) in melaem mode
+    # Its first dimension is the actual number of analysis frames.
     aem = aemg.compute(y.T)
-    # assert aem.shape[0] == len(time_stamp)
+
+    # Generate one timestamp for each AEM frame.
+    time_stamp = (
+        np.arange(aem.shape[0], dtype=float)
+        * audio_hop_length
+        / sr_
+    )
 
     # save aem
     if save_dir is not None:


### PR DESCRIPTION
## Summary

Fixes an off-by-one mismatch between the number of AEM frames and generated timestamps in `compute_aem()`.

## Problem

For a 25-second, 48 kHz FOA file using the default settings:

- `audio_frame_length=4800`
- `fps=20`
- `audio_hop_length=2400`

the AEM computation produced 499 frames, while the timestamp calculation produced only 498 timestamps.

This caused `anglegram()` to fail with:

```text
IndexError: boolean index did not match indexed array along axis 0
```

The previous timestamp calculation used `np.arange()` with an exclusive stop value, so the final valid frame start was omitted.

## Fix

The AEM is now computed first, and timestamps are generated from the actual AEM frame count:

```python
time_stamp = (
    np.arange(aem.shape[0], dtype=float)
    * audio_hop_length
    / sr_
)
```

This ensures that each AEM frame has exactly one corresponding timestamp.

## Verification

Before the fix:

- AEM frames: 499
- Timestamps: 498
- `anglegram()` raised an `IndexError`

After the fix:

- AEM frames: 499
- Timestamps: 499
- First timestamp: 0.0
- Last timestamp: 24.9
- `anglegram()` renders successfully